### PR TITLE
* remove fillAddress() due to missing it.

### DIFF
--- a/src/maps.coffee
+++ b/src/maps.coffee
@@ -55,17 +55,17 @@ module.exports = (robot) ->
 
   robot.respond /(?:(satellite|terrain|hybrid)[- ])?map( me)? (.+)/i, (msg) ->
     mapType  = msg.match[1] or "roadmap"
-    location = fillAddress(msg.match[3])
+    location = encodeURIComponent(msg.match[3])
     mapUrl   = "http://maps.google.com/maps/api/staticmap?markers=" +
-                escape(location) +
+                location +
                 "&size=400x400&maptype=" +
                 mapType +
                 "&sensor=false" +
                 "&format=png" # So campfire knows it's an image
     url      = "http://maps.google.com/maps?q=" +
-               escape(location) +
+               location +
               "&hl=en&sll=37.0625,-95.677068&sspn=73.579623,100.371094&vpsrc=0&hnear=" +
-              escape(location) +
+              location +
               "&t=m&z=11"
 
     msg.send mapUrl


### PR DESCRIPTION
* use 'encodeURIComponent()' instead of 'escape()' to support multi-byte
  characters on query like Japanese.